### PR TITLE
COMP: prevented GetMyBoundingBox from being declared twice

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObject.h
@@ -486,9 +486,15 @@ protected:
 
   itkSetMacro(TypeName, std::string);
 
-  itkGetModifiableObjectMacro(MyBoundingBox, BoundingBoxType);
+  virtual BoundingBoxType * GetModifiableMyBoundingBox()
+    {
+    return m_MyBoundingBox.GetPointer();
+    }
 
-  itkGetModifiableObjectMacro(FamilyBoundingBox, BoundingBoxType);
+  virtual BoundingBoxType * GetModifiableFamilyBoundingBox()
+    {
+    return m_FamilyBoundingBox.GetPointer();
+    }
 
 private:
 


### PR DESCRIPTION
itkGetModifiableObjectMacro internally calls itkGetConstObjectMacro, which conflicts with the code in SpatialObject that declares GetMyBoundingBox() as public. I made this change into its own pull request because I'm not sure my resolution of the problem is correct.