### PR TITLE
ENH: Update PolygonGroup IO to use new spatial object classes

### DIFF
--- a/Modules/IO/SpatialObjects/include/itkPolygonGroupSpatialObjectXMLFile.h
+++ b/Modules/IO/SpatialObjects/include/itkPolygonGroupSpatialObjectXMLFile.h
@@ -19,12 +19,14 @@
 #define itkPolygonGroupSpatialObjectXMLFile_h
 
 
-#include "itkPolygonGroupSpatialObject.h"
 #include "itkXMLFile.h"
+#include "itkGroupSpatialObject.h"
+#include "itkPolygonSpatialObject.h"
+
 namespace itk
 {
 /* 3D Polygon Groups only ones that make sense for this data type */
-using PGroupSpatialObjectType = PolygonGroupSpatialObject< 3 >;
+using GroupSpatialObjectType = GroupSpatialObject< 3 >;
 
 /** \class PolygonGroupSpatialObjectXMLFileReader
  *
@@ -33,20 +35,20 @@ using PGroupSpatialObjectType = PolygonGroupSpatialObject< 3 >;
  * \ingroup ITKIOSpatialObjects
  */
 class PolygonGroupSpatialObjectXMLFileReader:
-  public XMLReader< PGroupSpatialObjectType >
+  public XMLReader< GroupSpatialObjectType >
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(PolygonGroupSpatialObjectXMLFileReader);
 
   /** Standard type alias */
   using Self = PolygonGroupSpatialObjectXMLFileReader;
-  using Superclass = XMLReader< PGroupSpatialObjectType >;
+  using Superclass = XMLReader< GroupSpatialObjectType >;
   using Pointer = SmartPointer< Self >;
 
-  using PolygonGroupType = PGroupSpatialObjectType;
+  using GroupType = GroupSpatialObjectType;
   using PolygonSpatialObjectType = PolygonSpatialObject< 3 >;
-  using PointType = SpatialObjectPoint< 3 >;
-  using PointListType = std::vector< PointType >;
+  using PolygonPointType = SpatialObjectPoint< 3 >;
+  using PolygonPointListType = std::vector< PolygonPointType >;
 
   /** Run-time type information (and related methods). */
   itkTypeMacro(PolygonGroupSpatialObjectXMLFileReader, XMLReader);
@@ -69,26 +71,26 @@ protected:
   void CharacterDataHandler(const char *inData, int inLength) override;
 
 private:
-  PGroupSpatialObjectType::Pointer  m_PGroup;
+  GroupSpatialObjectType::Pointer   m_Group;
   PolygonSpatialObjectType::Pointer m_CurPoly;
-  PointListType                     m_CurPointList;
+  PolygonPointListType              m_CurPointList;
   std::string                       m_CurCharacterData;
 };
 
 /** \class PolygonGroupSpatialObjectXMLFileWriter
  *
  * Writes an XML-format file containing a list of polygons,
- * based on a PolygonGroupSpatialObject.
+ * based on a GroupSpatialObject.
  * \ingroup ITKIOSpatialObjects
  */
 class PolygonGroupSpatialObjectXMLFileWriter:
-  public XMLWriterBase< PGroupSpatialObjectType >
+  public XMLWriterBase< GroupSpatialObjectType >
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(PolygonGroupSpatialObjectXMLFileWriter);
 
   /** standard type alias */
-  using Superclass = XMLWriterBase< PGroupSpatialObjectType >;
+  using Superclass = XMLWriterBase< GroupSpatialObjectType >;
   using Self = PolygonGroupSpatialObjectXMLFileWriter;
   using Pointer = SmartPointer< Self >;
 
@@ -97,8 +99,8 @@ public:
 
   /** Run-time type information (and related methods). */
   itkTypeMacro(PolygonGroupSpatialObjectXMLFileWriter,
-               XMLWriterBase< PGroupSpatialObjectType > );
-  using PolygonGroupType = PGroupSpatialObjectType;
+               XMLWriterBase< GroupSpatialObjectType > );
+  using GroupType = GroupSpatialObjectType;
   using PolygonSpatialObjectType = PolygonSpatialObject< 3 >;
   /** Test whether a file is writable. */
   int CanWriteFile(const char *name) override;

--- a/Modules/IO/SpatialObjects/src/itkPolygonGroupSpatialObjectXMLFile.cxx
+++ b/Modules/IO/SpatialObjects/src/itkPolygonGroupSpatialObjectXMLFile.cxx
@@ -131,8 +131,8 @@ PolygonGroupSpatialObjectXMLFileReader::EndElement(const char *name)
         s = endptr;
         }
       }
-    PointType p;
-    p.SetPosition(pval);
+    PolygonPointType p;
+    p.SetPositionInObjectSpace(pval);
     m_CurPointList.push_back(p);
     }
   else if ( itksys::SystemTools::Strucmp(name, "POLYGON") == 0 )
@@ -246,21 +246,24 @@ PolygonGroupSpatialObjectXMLFileWriter::WriteFile()
 
   //
   // Write out polygondata
-  PolygonGroupType::ChildrenListType *children =
-    m_InputObject->GetChildren(0, nullptr);
+  GroupType::ChildrenListType *children =
+    m_InputObject->GetChildren(GroupType::MaximumDepth, "PolygonSpatialObject");
   auto it = children->begin();
   auto end = children->end();
   while ( it != end )
     {
     WriteStartElement("POLYGON", output);
     output << std::endl;
-    auto * curstrand = dynamic_cast< PolygonSpatialObjectType * >( ( *it ).GetPointer() );
-    PolygonSpatialObjectType::PointListType &         points = curstrand->GetPoints();
-    auto pointIt = points.begin();
-    auto pointItEnd = points.end();
+    auto * curstrand = dynamic_cast< PolygonSpatialObjectType * >(
+      ( *it ).GetPointer() );
+    PolygonSpatialObjectType::PolygonPointListType & polygonPoints =
+      curstrand->GetPoints();
+    auto pointIt = polygonPoints.begin();
+    auto pointItEnd = polygonPoints.end();
     while ( pointIt != pointItEnd )
       {
-      PolygonSpatialObjectType::PointType curpoint = ( *pointIt ).GetPosition();
+      PolygonSpatialObjectType::PointType curpoint =
+        ( *pointIt ).GetPositionInObjectSpace();
       WriteStartElement("POINT", output);
       output << curpoint[0] << " " << curpoint[1] << " "  << curpoint[2];
       WriteEndElement("POINT", output);


### PR DESCRIPTION
PolygGroupSpatialObjects offered limited functionality beyond a GroupSpatialObject.   That functionality should be provided via helper functions, not by subclassing group which limits the flexibility of the tree architecture and duplicates the purpose of the Depth and Name arguments to scope computations on the tree.
