### PR TITLE
ENH: Updated itkGetObjectMacro to itkGetModifiableObjectMacro

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.h
@@ -75,10 +75,10 @@ public:
   itkGetConstReferenceMacro(LengthInObjectSpace, double);
 
   /** Compute the Object bounding box */
-  bool ComputeMyBoundingBoxInWorldSpace() const override;
+  bool ComputeMyBoundingBox() const override;
 
   /** Returns true if the point is inside the line, false otherwise. */
-  bool IsInsideInWorldSpace(const PointType & point, unsigned int depth=0,
+  bool IsInsideInObjectSpace(const PointType & point, unsigned int depth=0,
     const std::string & name="") const override;
 
   void Update() override;

--- a/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkArrowSpatialObject.hxx
@@ -60,26 +60,16 @@ ArrowSpatialObject< TDimension >
 template< unsigned int TDimension >
 bool
 ArrowSpatialObject< TDimension >
-::ComputeMyBoundingBoxInWorldSpace() const
+::ComputeMyBoundingBox() const
 {
   itkDebugMacro("Computing Rectangle bounding box");
 
   PointType pnt = this->GetPositionInObjectSpace();
-  PointType pnt2;
-  for ( unsigned int i = 0; i < TDimension; i++ )
-    {
-    pnt2[i] = pnt[i] + m_LengthInObjectSpace * m_DirectionInObjectSpace[i];
-    }
-
-  pnt = this->GetObjectToWorldTransform()->TransformPoint(pnt);
-  pnt2 = this->GetObjectToWorldTransform()->TransformPoint(pnt2);
 
   const_cast< typename Superclass::BoundingBoxType * >(
-    this->GetMyBoundingBoxInWorldSpace() )->SetMinimum(pnt);
+    this->GetMyBoundingBoxInObjectSpace() )->SetMinimum(pnt);
   const_cast< typename Superclass::BoundingBoxType * >(
-    this->GetMyBoundingBoxInWorldSpace() )->SetMaximum(pnt);
-  const_cast< typename Superclass::BoundingBoxType * >(
-    this->GetMyBoundingBoxInWorldSpace() )->ConsiderPoint(pnt2);
+    this->GetMyBoundingBoxInObjectSpace() )->SetMaximum(pnt);
 
   return true;
 }
@@ -88,42 +78,37 @@ ArrowSpatialObject< TDimension >
 template< unsigned int TDimension >
 bool
 ArrowSpatialObject< TDimension >
-::IsInsideInWorldSpace(const PointType & point, unsigned int depth,
+::IsInsideInObjectSpace(const PointType & point, unsigned int depth,
   const std::string & name) const
 {
   itkDebugMacro("Checking the point [" << point << "] is on the Line");
 
   if( this->GetTypeName().find( name ) != std::string::npos )
     {
-    if ( this->GetMyBoundingBoxInWorldSpace()->IsInside(point) )
+    PointType pnt = this->GetPositionInObjectSpace();
+
+    PointType tPnt = this->GetObjectToWorldTransform()
+      ->GetInverseTransform()->TransformPoint(point);
+
+    bool isInside = true;
+    for ( unsigned int i = 0; i < TDimension; i++ )
       {
-      PointType transformedPoint = this->GetObjectToWorldTransform()
-        ->GetInverseTransform()->TransformPoint(point);
-
-      PointType pnt = this->GetPositionInObjectSpace();
-      PointType pnt2;
-      for ( unsigned int i = 0; i < TDimension; i++ )
+      if( Math::NotExactlyEquals( pnt[i], tPnt[i] ) )
         {
-        pnt2[i] = pnt[i] + m_LengthInObjectSpace * m_DirectionInObjectSpace[i];
+        isInside = false;
+        break;
         }
-
-      VectorType v = pnt2 - pnt;
-      VectorType v2 = transformedPoint - pnt;
-
-      v.Normalize();
-      v2.Normalize();
-
-      if ( Math::AlmostEquals( dot_product( v.GetVnlVector(), v2.GetVnlVector() ),
-          NumericTraits< typename VectorType::ValueType >::OneValue() ) )
-        {
-        return true;
-        }
+      }
+    if( isInside )
+      {
+      return true;
       }
     }
 
   if( depth > 0 )
     {
-    return Superclass::IsInsideChildrenInWorldSpace( point, depth-1, name );
+    std::cout << "Testing children" << std::endl;
+    return Superclass::IsInsideChildrenInObjectSpace( point, depth-1, name );
     }
 
   return false;

--- a/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.h
@@ -81,13 +81,13 @@ public:
   itkGetConstObjectMacro(Corners, PointsContainerType);
 
   /** Test whether a point is inside or outside the object */
-  bool IsInsideInWorldSpace(const PointType & point, unsigned int depth = 0,
+  bool IsInsideInObjectSpace(const PointType & point, unsigned int depth = 0,
     const std::string & name = "" ) const override;
 
   /** Get the boundaries of a specific object.  This function needs to
    *  be called every time one of the object's components is
    *  changed. */
-  bool ComputeMyBoundingBoxInWorldSpace() const override;
+  bool ComputeMyBoundingBox() const override;
 
   /** world-space getters */
   itkGetConstReferenceMacro( Position, PointType );

--- a/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkBoxSpatialObject.hxx
@@ -44,38 +44,22 @@ BoxSpatialObject< TDimension >
 template< unsigned int TDimension >
 bool
 BoxSpatialObject< TDimension >
-::IsInsideInWorldSpace(const PointType & worldPoint, unsigned int depth,
+::IsInsideInObjectSpace(const PointType & point, unsigned int depth,
   const std::string & name) const
 {
-  itkDebugMacro("Checking the point [" << worldPoint << "] is in the box");
+  itkDebugMacro("Checking the point [" << point << "] is in the box");
 
   if( this->GetTypeName().find( name ) != std::string::npos )
     {
-    if( this->GetMyBoundingBoxInWorldSpace()->IsInside( worldPoint ) )
+    if( this->GetMyBoundingBoxInObjectSpace()->IsInside( point ) )
       {
-      PointType transformedPoint = this->GetObjectToWorldTransform()
-        ->GetInverseTransform()->TransformPoint(worldPoint);
-
-      bool isOutside = false;
-      for ( unsigned int i = 0; i < TDimension; i++ )
-        {
-        if ( ( transformedPoint[i] - m_PositionInObjectSpace[i] > m_SizeInObjectSpace[i] )
-          || ( transformedPoint[i] - m_PositionInObjectSpace[i] < 0 ) )
-          {
-          isOutside = true;
-          break;
-          }
-        }
-      if( !isOutside )
-        {
-        return true;
-        }
+      return true;
       }
     }
 
   if( depth > 0 )
     {
-    return Superclass::IsInsideChildrenInWorldSpace(worldPoint, depth-1, name);
+    return Superclass::IsInsideChildrenInObjectSpace(point, depth-1, name);
     }
 
   return false;
@@ -85,7 +69,7 @@ BoxSpatialObject< TDimension >
 template< unsigned int TDimension >
 bool
 BoxSpatialObject< TDimension >
-::ComputeMyBoundingBoxInWorldSpace() const
+::ComputeMyBoundingBox() const
 {
   itkDebugMacro("Computing BoxSpatialObject bounding box");
 
@@ -97,16 +81,13 @@ BoxSpatialObject< TDimension >
     pnt2[i] = m_PositionInObjectSpace[i] + m_SizeInObjectSpace[i];
     }
 
-  pnt1 = this->GetObjectToWorldTransform()->TransformPoint(pnt1);
-  pnt2 = this->GetObjectToWorldTransform()->TransformPoint(pnt2);
-
-  const_cast< BoundingBoxType * >( this->GetMyBoundingBoxInWorldSpace() )
+  const_cast< BoundingBoxType * >( this->GetMyBoundingBoxInObjectSpace() )
     ->SetMinimum(pnt1);
-  const_cast< BoundingBoxType * >( this->GetMyBoundingBoxInWorldSpace() )
+  const_cast< BoundingBoxType * >( this->GetMyBoundingBoxInObjectSpace() )
     ->SetMaximum(pnt1);
-  const_cast< BoundingBoxType * >( this->GetMyBoundingBoxInWorldSpace() )
+  const_cast< BoundingBoxType * >( this->GetMyBoundingBoxInObjectSpace() )
     ->ConsiderPoint(pnt2);
-  this->GetMyBoundingBoxInWorldSpace()->ComputeBoundingBox();
+  this->GetMyBoundingBoxInObjectSpace()->ComputeBoundingBox();
 
   return true;
 }

--- a/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkContourSpatialObject.hxx
@@ -139,7 +139,8 @@ ContourSpatialObject< TDimension >
           }
         typename Superclass::SpatialObjectPointType newSOPoint;
         newSOPoint = (*it);
-        newSOPoint.SetPositionInWorldSpace( newPoint );
+        newSOPoint.SetSpatialObject( this );
+        newSOPoint.SetPositionInObjectSpace( newPoint );
         this->m_Points.push_back( newSOPoint );
         }
       break;

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.h
@@ -87,16 +87,16 @@ public:
   itkGetConstReferenceMacro(CenterInObjectSpace, PointType);
 
   /** Test whether a point is inside or outside the object */
-  bool IsInsideInWorldSpace(const PointType & point, unsigned int depth=0,
+  bool IsInsideInObjectSpace(const PointType & point, unsigned int depth=0,
     const std::string & name="" ) const override;
 
   /** Get the boundaries of a specific object.  This function needs to
    *  be called every time one of the object's components is
    *  changed. */
-  bool ComputeMyBoundingBoxInWorldSpace() const override;
+  bool ComputeMyBoundingBox() const override;
 
   /** world-space property getters */
-  itkGetConstReferenceMacro( Center, PointType );
+  itkGetConstReferenceMacro( CenterInWorldSpace, PointType );
 
   void Update() override;
 
@@ -108,7 +108,7 @@ protected:
   ArrayType m_RadiusInObjectSpace;
   PointType m_CenterInObjectSpace;
   /* world space */
-  PointType m_Center;
+  PointType m_CenterInWorldSpace;
 
   /** Print the object informations in a stream. */
   void PrintSelf(std::ostream & os, Indent indent) const override;

--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
@@ -45,23 +45,20 @@ EllipseSpatialObject< TDimension >
 template< unsigned int TDimension >
 bool
 EllipseSpatialObject< TDimension >
-::IsInsideInWorldSpace(const PointType & worldPoint, unsigned int depth,
+::IsInsideInObjectSpace(const PointType & point, unsigned int depth,
   const std::string & name) const
 {
   if( this->GetTypeName().find( name ) != std::string::npos )
     {
-    PointType transformedPoint = this->GetObjectToWorldTransform()
-      ->GetInverseTransform()->TransformPoint(worldPoint);
-
     double r = 0;
     for ( unsigned int i = 0; i < TDimension; i++ )
       {
       if ( m_RadiusInObjectSpace[i] != 0.0 )
         {
-        r += ( transformedPoint[i] * transformedPoint[i] )
+        r += ( point[i] * point[i] )
              / ( m_RadiusInObjectSpace[i] * m_RadiusInObjectSpace[i] );
         }
-      else if ( transformedPoint[i] > 0.0 )  // Degenerate ellipse
+      else if ( point[i] > 0.0 )  // Degenerate ellipse
         {
         r = 2; // Keeps function from returning true here
         break;
@@ -76,7 +73,7 @@ EllipseSpatialObject< TDimension >
 
   if( depth > 0 )
     {
-    return Superclass::IsInsideChildrenInWorldSpace( worldPoint, depth-1, name );
+    return Superclass::IsInsideChildrenInObjectSpace( point, depth-1, name );
     }
 
   return false;
@@ -86,50 +83,22 @@ EllipseSpatialObject< TDimension >
 template< unsigned int TDimension >
 bool
 EllipseSpatialObject< TDimension >
-::ComputeMyBoundingBoxInWorldSpace() const
+::ComputeMyBoundingBox() const
 {
   itkDebugMacro("Computing ellipse bounding box");
 
-  // First we compute the bounding box in the object space
-  typename BoundingBoxType::Pointer bb = BoundingBoxType::New();
-
   PointType    pnt1;
   PointType    pnt2;
-  unsigned int i;
-  for ( i = 0; i < TDimension; i++ )
+  for ( unsigned int i = 0; i < TDimension; i++ )
     {
     pnt1[i] = m_CenterInObjectSpace[i] - m_RadiusInObjectSpace[i];
     pnt2[i] = m_CenterInObjectSpace[i] + m_RadiusInObjectSpace[i];
     }
 
-  bb->SetMinimum(pnt1);
-  bb->SetMaximum(pnt1);
-  bb->ConsiderPoint(pnt2);
-  bb->ComputeBoundingBox();
-
-  // Next Transform the corners of the bounding box
-  using PointsContainer = typename BoundingBoxType::PointsContainer;
-  const PointsContainer *corners = bb->GetCorners();
-  typename PointsContainer::Pointer transformedCorners =
-    PointsContainer::New();
-  transformedCorners->Reserve(
-    static_cast<typename PointsContainer::ElementIdentifier>(
-      corners->size() ) );
-
-  auto it = corners->begin();
-  auto itTrans = transformedCorners->begin();
-  while ( it != corners->end() )
-    {
-    PointType pnt = this->GetObjectToWorldTransform()->TransformPoint(*it);
-    *itTrans = pnt;
-    ++it;
-    ++itTrans;
-    }
-
-  // refresh the bounding box with the transformed corners
-  const_cast< BoundingBoxType * >( this->GetMyBoundingBoxInWorldSpace() )
-    ->SetPoints(transformedCorners);
-  this->GetMyBoundingBoxInWorldSpace()->ComputeBoundingBox();
+  this->GetMyBoundingBoxInObjectSpace()->SetMinimum(pnt1);
+  this->GetMyBoundingBoxInObjectSpace()->SetMaximum(pnt1);
+  this->GetMyBoundingBoxInObjectSpace()->ConsiderPoint(pnt2);
+  this->GetMyBoundingBoxInObjectSpace()->ComputeBoundingBox();
 
   return true;
 }
@@ -143,10 +112,10 @@ EllipseSpatialObject< TDimension >
   PointType center = this->GetCenterInObjectSpace();
   PointType worldCenter;
 
-  worldCenter = this->GetObjectToWorldTransform()->TransformPoint( center );
-  m_Center = worldCenter;
-
   Superclass::Update();
+
+  worldCenter = this->GetObjectToWorldTransform()->TransformPoint( center );
+  m_CenterInWorldSpace = worldCenter;
 }
 
 /** Print Self function */
@@ -159,7 +128,7 @@ EllipseSpatialObject< TDimension >
   Superclass::PrintSelf(os, indent);
   os << "Object Radius: " << m_RadiusInObjectSpace << std::endl;
   os << "Object Center: " << m_CenterInObjectSpace << std::endl;
-  os << "World Center: " << m_Center << std::endl;
+  os << "World Center: " << m_CenterInWorldSpace << std::endl;
 }
 
 } // end namespace itk

--- a/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkGaussianSpatialObject.h
@@ -80,18 +80,20 @@ public:
   itkSetMacro(Maximum, ScalarType);
   itkGetConstReferenceMacro(Maximum, ScalarType);
 
+  ScalarType SquaredZScoreInObjectSpace(const PointType & point) const;
+
   ScalarType SquaredZScoreInWorldSpace(const PointType & point) const;
 
   /** Test whether a point is inside or outside the object */
-  bool IsInsideInWorldSpace(const PointType & point, unsigned int depth = 0,
+  bool IsInsideInObjectSpace(const PointType & point, unsigned int depth = 0,
     const std::string & name = "") const override;
 
   /** This function needs to be called every time one of the object's
    *  components is changed. */
-  bool ComputeMyBoundingBoxInWorldSpace() const override;
+  bool ComputeMyBoundingBox() const override;
 
   /** Returns the value of the Gaussian at the given point.  */
-  bool ValueAtInWorldSpace(const PointType & point, double & value,
+  bool ValueAtInObjectSpace(const PointType & point, double & value,
     unsigned int depth = 0, const std::string & name = "") const override;
 
   /** Returns the sigma=m_Radius level set of the Gaussian function, as an

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.h
@@ -26,7 +26,8 @@ namespace itk
 /** \class ImageMaskSpatialObject
  * \brief Implementation of an image mask as spatial object.
  *
- * This class derives from the ImageSpatialObject and overloads the IsInsideInWorldSpace()
+ * This class derives from the ImageSpatialObject and overloads the
+ * IsInsideInObjectSpace()
  * method.  One of the common uses of this class is to serve as Mask for the
  * Image Registration Metrics.
  *
@@ -67,13 +68,13 @@ public:
   itkTypeMacro(ImageMaskSpatialObject, ImageSpatialObject);
 
   /** Returns true if the point is inside, false otherwise. */
-  bool IsInsideInWorldSpace(const PointType & point, unsigned int depth=0,
+  bool IsInsideInObjectSpace(const PointType & point, unsigned int depth=0,
     const std::string & name="") const override;
 
   /** Get the boundaries of a specific object.  This function needs to
    *  be called every time one of the object's components is
    *  changed. */
-  bool ComputeMyBoundingBoxInWorldSpace() const override;
+  bool ComputeMyBoundingBox() const override;
 
 protected:
   ImageMaskSpatialObject();

--- a/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkImageMaskSpatialObject.hxx
@@ -43,36 +43,33 @@ ImageMaskSpatialObject< TDimension, TPixel >
 template< unsigned int TDimension, typename TPixel >
 bool
 ImageMaskSpatialObject< TDimension, TPixel >
-::IsInsideInWorldSpace(const PointType & point, unsigned int depth,
+::IsInsideInObjectSpace(const PointType & point, unsigned int depth,
   const std::string & name ) const
 {
   if( this->GetTypeName().find( name ) != std::string::npos )
     {
-    if( this->GetMyBoundingBoxInWorldSpace()->IsInside(point) )
+    if( this->GetMyBoundingBoxInObjectSpace()->IsInside(point) )
       {
-      PointType p = this->GetObjectToWorldTransform()->GetInverseTransform()->
-        TransformPoint(point);
-
       typename Superclass::InterpolatorType::ContinuousIndexType index;
-      bool inside_image = this->m_Image->TransformPhysicalPointToContinuousIndex( p,
-        index );
-      if( inside_image ){
-          using InterpolatorOutputType = typename InterpolatorType::OutputType;
-          bool insideMask = (
-            Math::NotExactlyEquals(
-              DefaultConvertPixelTraits<InterpolatorOutputType>::GetScalarValue(
-                this->m_Interpolator->EvaluateAtContinuousIndex(index)),
-              NumericTraits<PixelType>::ZeroValue() ) );
-          if( insideMask )
-            {
-            return true;
-            }
+      if( this->m_Image->TransformPhysicalPointToContinuousIndex( point,
+          index ) )
+        {
+        using InterpolatorOutputType = typename InterpolatorType::OutputType;
+        bool insideMask = (
+          Math::NotExactlyEquals(
+            DefaultConvertPixelTraits<InterpolatorOutputType>::GetScalarValue(
+              this->m_Interpolator->EvaluateAtContinuousIndex(index)),
+            NumericTraits<PixelType>::ZeroValue() ) );
+        if( insideMask )
+          {
+          return true;
           }
+        }
       }
     }
   if( depth > 0 )
     {
-    return Superclass::IsInsideChildrenInWorldSpace( point, depth, name );
+    return Superclass::IsInsideChildrenInObjectSpace( point, depth, name );
     }
 
   return false;
@@ -81,23 +78,22 @@ ImageMaskSpatialObject< TDimension, TPixel >
 template< unsigned int TDimension, typename TPixel >
 bool
 ImageMaskSpatialObject< TDimension, TPixel >
-::ComputeMyBoundingBoxInWorldSpace() const
+::ComputeMyBoundingBox() const
 {
   using IteratorType = ImageRegionConstIteratorWithIndex< ImageType >;
-  IteratorType it( this->m_Image, this->m_Image->GetLargestPossibleRegion() );
-  IteratorType prevIt( this->m_Image, this->m_Image->GetLargestPossibleRegion() );
+  IteratorType it( this->m_Image,
+    this->m_Image->GetLargestPossibleRegion() );
+  IteratorType prevIt( this->m_Image,
+    this->m_Image->GetLargestPossibleRegion() );
   it.GoToBegin();
   prevIt = it;
 
-  // TODO: Could be made faster by computing BB in object space and
-  //   then transforming its corners to world space.
   bool first = true;
   PixelType outsideValue = NumericTraits< PixelType >::ZeroValue();
   PixelType value = outsideValue;
   PixelType prevValue = outsideValue;
   IndexType tmpIndex;
   PointType tmpPoint;
-  PointType transformedPoint;
   while ( !it.IsAtEnd() )
     {
     value = it.Get();
@@ -113,17 +109,15 @@ ImageMaskSpatialObject< TDimension, TPixel >
         tmpIndex = it.GetIndex();
         }
       this->m_Image->TransformIndexToPhysicalPoint( tmpIndex, tmpPoint );
-      transformedPoint =
-        this->GetObjectToWorldTransform()->TransformPoint( tmpPoint );
       if( first )
         {
         first = false;
-        this->GetMyBoundingBoxInWorldSpace()->SetMinimum( transformedPoint );
-        this->GetMyBoundingBoxInWorldSpace()->SetMaximum( transformedPoint );
+        this->GetMyBoundingBoxInObjectSpace()->SetMinimum( tmpPoint );
+        this->GetMyBoundingBoxInObjectSpace()->SetMaximum( tmpPoint );
         }
       else
         {
-        this->GetMyBoundingBoxInWorldSpace()->ConsiderPoint( transformedPoint );
+        this->GetMyBoundingBoxInObjectSpace()->ConsiderPoint( tmpPoint );
         }
       }
     prevIt = it;
@@ -132,12 +126,12 @@ ImageMaskSpatialObject< TDimension, TPixel >
 
   if( first )
     {
-    transformedPoint.Fill(
+    tmpPoint.Fill(
       NumericTraits< typename BoundingBoxType::PointType::ValueType >::
       ZeroValue() );
 
-    this->GetMyBoundingBoxInWorldSpace()->SetMinimum( transformedPoint );
-    this->GetMyBoundingBoxInWorldSpace()->SetMaximum( transformedPoint );
+    this->GetMyBoundingBoxInObjectSpace()->SetMinimum( tmpPoint );
+    this->GetMyBoundingBoxInObjectSpace()->SetMaximum( tmpPoint );
 
     return false;
     }

--- a/Modules/Core/SpatialObjects/include/itkImageSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkImageSpatialObject.h
@@ -79,26 +79,26 @@ public:
   const ImageType * GetImage() const;
 
   /** Compute the boundaries of the image spatial object. */
-  bool ComputeMyBoundingBoxInWorldSpace() const override;
+  bool ComputeMyBoundingBox() const override;
 
   /** Returns true if the point is inside, false otherwise. */
-  bool IsInsideInWorldSpace(const PointType & point, unsigned int depth=0,
+  bool IsInsideInObjectSpace(const PointType & point, unsigned int depth=0,
     const std::string & name = "") const override;
 
   /** Returns the value of the image at the requested point.
    *  Returns true if that value is valid */
-  bool ValueAtInWorldSpace(const PointType & point, double & value, unsigned int depth = 0,
-    const std::string & name = "") const override;
+  bool ValueAtInObjectSpace(const PointType & point, double & value,
+    unsigned int depth = 0, const std::string & name = "") const override;
 
   /** Returns the latest modified time of the object and its component. */
   ModifiedTimeType GetMTime() const override;
 
   /** Set the slice position */
-  void SetSlicePositionInWorldSpace(unsigned int dimension, int position);
+  void SetSliceNumber(unsigned int dimension, int position);
 
   /** Get the slice position */
-  int GetSlicePositionInWorldSpace(unsigned int dimension)
-  { return m_SlicePosition[dimension]; }
+  int GetSliceNumber(unsigned int dimension)
+  { return m_SliceNumber[dimension]; }
 
   const char * GetPixelTypeName()
   { return m_PixelType.c_str(); }
@@ -115,7 +115,7 @@ protected:
 
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
-  IndexType       m_SlicePosition;
+  IndexType       m_SliceNumber;
   std::string     m_PixelType;
 
   typename InterpolatorType::Pointer m_Interpolator;

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObject.h
@@ -73,7 +73,7 @@ public:
 
   /** Returns true if the line is evaluable at the requested point,
    *  false otherwise. */
-  bool IsInsideInWorldSpace(const PointType & point, unsigned int depth = 0,
+  bool IsInsideInObjectSpace(const PointType & point, unsigned int depth = 0,
    const std::string & name = "") const override;
 
 protected:

--- a/Modules/Core/SpatialObjects/include/itkLineSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkLineSpatialObject.hxx
@@ -53,7 +53,7 @@ LineSpatialObject< TDimension >
 template< unsigned int TDimension >
 bool
 LineSpatialObject< TDimension >
-::IsInsideInWorldSpace(const PointType & point, unsigned int depth,
+::IsInsideInObjectSpace(const PointType & point, unsigned int depth,
   const std::string & name) const
 {
   if( this->GetTypeName().find( name ) != std::string::npos )
@@ -61,10 +61,7 @@ LineSpatialObject< TDimension >
     auto it = this->m_Points.begin();
     auto itEnd = this->m_Points.end();
 
-    PointType transformedPoint = this->GetObjectToWorldTransform()
-      ->GetInverseTransform()->TransformPoint(point);
-
-    if ( this->GetMyBoundingBoxInWorldSpace()->IsInside(transformedPoint) )
+    if ( this->GetMyBoundingBoxInObjectSpace()->IsInside(point) )
       {
       while ( it != itEnd )
         {
@@ -72,7 +69,7 @@ LineSpatialObject< TDimension >
         for( unsigned int i=0; i<TDimension; ++i )
           {
           if ( ! Math::AlmostEquals( ( *it ).GetPositionInObjectSpace()[i],
-                   transformedPoint[i] ) )
+                   point[i] ) )
             {
             match = false;
             break;
@@ -89,7 +86,7 @@ LineSpatialObject< TDimension >
 
   if( depth > 0 )
     {
-    return Superclass::IsInsideChildrenInWorldSpace( point, depth-1, name );
+    return Superclass::IsInsideChildrenInObjectSpace( point, depth-1, name );
     }
 
 

--- a/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.h
@@ -71,11 +71,11 @@ public:
   const MeshType *GetMesh() const;
 
   /** Returns true if the point is inside, false otherwise. */
-  bool IsInsideInWorldSpace(const PointType & point, unsigned int depth=0,
+  bool IsInsideInObjectSpace(const PointType & point, unsigned int depth=0,
     const std::string & name="") const override;
 
   /** Compute the boundaries of the iamge spatial object. */
-  bool ComputeMyBoundingBoxInWorldSpace() const override;
+  bool ComputeMyBoundingBox() const override;
 
   /** Returns the latest modified time of the object and its component. */
   ModifiedTimeType GetMTime() const override;
@@ -86,20 +86,20 @@ public:
     return m_PixelType.c_str();
   }
 
-  /** Set/Get the precision for the IsInsideInWorldSpace function.
+  /** Set/Get the precision for the IsInsideInObjectSpace function.
    *  This is used when the cell is a triangle, in this case, it's more likely
    *  that the given point will not be falling exactly on the triangle surface.
    *  If the distance from the point to the surface is <= to
-   *  m_IsInsidePrecisionInWorldSpacethe point is considered inside the mesh.
+   *  m_IsInsidePrecisionInObjectSpace the point is considered inside the mesh.
    *  The default value is 1. */
-  itkSetMacro(IsInsidePrecisionInWorldSpace, double);
-  itkGetMacro(IsInsidePrecisionInWorldSpace, double);
+  itkSetMacro(IsInsidePrecisionInObjectSpace, double);
+  itkGetMacro(IsInsidePrecisionInObjectSpace, double);
 
 protected:
 
   MeshPointer m_Mesh;
   std::string m_PixelType;
-  double      m_IsInsidePrecisionInWorldSpace;
+  double      m_IsInsidePrecisionInObjectSpace;
 
   MeshSpatialObject();
   ~MeshSpatialObject() override;

--- a/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMeshSpatialObject.hxx
@@ -31,7 +31,7 @@ MeshSpatialObject< TMesh >
   this->SetTypeName("MeshSpatialObject");
   m_Mesh = MeshType::New();
   m_PixelType = typeid( typename TMesh::PixelType ).name();
-  m_IsInsidePrecisionInWorldSpace = 1;
+  m_IsInsidePrecisionInObjectSpace = 1;
 }
 
 /** Destructor */
@@ -45,16 +45,13 @@ MeshSpatialObject< TMesh >
 template< typename TMesh >
 bool
 MeshSpatialObject< TMesh >
-::IsInsideInWorldSpace(const PointType & point, unsigned int depth,
+::IsInsideInObjectSpace(const PointType & point, unsigned int depth,
   const std::string & name) const
 {
   if( this->GetTypeName().find( name ) != std::string::npos )
     {
-    if( this->GetMyBoundingBoxInWorldSpace()->IsInside( point ) )
+    if( this->GetMyBoundingBoxInObjectSpace()->IsInside( point ) )
       {
-      PointType transformedPoint = this->GetObjectToWorldTransform()->
-        GetInverseTransform()->TransformPoint(point);
-
       typename MeshType::CellsContainerPointer cells =  m_Mesh->GetCells();
       typename MeshType::CellsContainer::ConstIterator it = cells->Begin();
       while ( it != cells->End() )
@@ -63,17 +60,18 @@ MeshSpatialObject< TMesh >
         CoordRepType position[Dimension];
         for ( unsigned int i = 0; i < Dimension; i++ )
           {
-          position[i] = transformedPoint[i];
+          position[i] = point[i];
           }
 
         // If this is a triangle cell we need to check the distance
         if ( it.Value()->GetNumberOfPoints() == 3 )
           {
           double minDist = 0.0;
-          const bool pointIsInsideInWorldSpace = it.Value()->EvaluatePosition(
+          const bool pointIsInsideInObjectSpace = it.Value()->EvaluatePosition(
             position, m_Mesh->GetPoints(), nullptr, nullptr, &minDist, nullptr);
 
-          if ( pointIsInsideInWorldSpace  && minDist <= this->m_IsInsidePrecisionInWorldSpace )
+          if ( pointIsInsideInObjectSpace
+            && minDist <= this->m_IsInsidePrecisionInObjectSpace )
             {
             return true;
             }
@@ -93,7 +91,7 @@ MeshSpatialObject< TMesh >
 
   if( depth > 0 )
     {
-    return Superclass::IsInsideChildrenInWorldSpace( point, depth-1, name );
+    return Superclass::IsInsideChildrenInObjectSpace( point, depth-1, name );
     }
 
   return false;
@@ -103,7 +101,7 @@ MeshSpatialObject< TMesh >
 template< typename TMesh >
 bool
 MeshSpatialObject< TMesh >
-::ComputeMyBoundingBoxInWorldSpace() const
+::ComputeMyBoundingBox() const
 {
   PointType pnt1;
   PointType pnt2;
@@ -113,38 +111,11 @@ MeshSpatialObject< TMesh >
     pnt2[i] = m_Mesh->GetBoundingBox()->GetBounds()[2 * i + 1];
     }
 
-  pnt1 = this->GetObjectToWorldTransform()->TransformPoint(pnt1);
-  pnt2 = this->GetObjectToWorldTransform()->TransformPoint(pnt2);
-
-  typename BoundingBoxType::Pointer bb = BoundingBoxType::New();
-  bb->SetMinimum(pnt1);
-  bb->SetMaximum(pnt1);
-  bb->ConsiderPoint(pnt2);
-  bb->ComputeBoundingBox();
-
-  // Next Transform the corners of the bounding box
-  using PointsContainer = typename BoundingBoxType::PointsContainer;
-  const PointsContainer *corners = bb->GetCorners();
-  typename PointsContainer::Pointer transformedCorners =
-    PointsContainer::New();
-  transformedCorners->Reserve(
-    static_cast<typename PointsContainer::ElementIdentifier>(
-      corners->size() ) );
-
-  auto it = corners->begin();
-  auto itTrans = transformedCorners->begin();
-  while ( it != corners->end() )
-    {
-    PointType pnt = this->GetObjectToWorldTransform()->TransformPoint(*it);
-    *itTrans = pnt;
-    ++it;
-    ++itTrans;
-    }
-
-  // refresh the bounding box with the transformed corners
-  const_cast< BoundingBoxType * >( this->GetMyBoundingBoxInWorldSpace() )
-    ->SetPoints(transformedCorners);
-  this->GetMyBoundingBoxInWorldSpace()->ComputeBoundingBox();
+  this->GetMyBoundingBoxInObjectSpace()->SetMinimum(
+    m_Mesh->GetBoundingBox()->GetMinimum() );
+  this->GetMyBoundingBoxInObjectSpace()->SetMaximum(
+    m_Mesh->GetBoundingBox()->GetMaximum() );
+  this->GetMyBoundingBoxInObjectSpace()->ComputeBoundingBox();
 
   return true;
 }
@@ -184,7 +155,8 @@ MeshSpatialObject< TMesh >
 {
   Superclass::PrintSelf(os, indent);
   os << "Mesh: " << std::endl;
-  os << "m_IsInsidePrecisionInWorldSpace: " << m_IsInsidePrecisionInWorldSpace << std::endl;
+  os << "m_IsInsidePrecisionInObjectSpace: "
+    << m_IsInsidePrecisionInObjectSpace << std::endl;
   os << indent << m_Mesh << std::endl;
 }
 

--- a/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkMetaSceneConverter.hxx
@@ -115,9 +115,9 @@ MetaSceneConverter< NDimensions, PixelType, TMeshTraits >
     center[i] = ( meta->CenterOfRotation() )[i];
     }
 
-  so->GetObjectToParentTransform()->SetCenter(center);
-  so->GetObjectToParentTransform()->SetMatrix(matrix);
-  so->GetObjectToParentTransform()->SetOffset(offset);
+  so->GetModifiableObjectToParentTransform()->SetCenter(center);
+  so->GetModifiableObjectToParentTransform()->SetMatrix(matrix);
+  so->GetModifiableObjectToParentTransform()->SetOffset(offset);
 }
 
 /** Convert a metaScene into a Composite Spatial Object

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.h
@@ -92,14 +92,18 @@ public:
   { return static_cast<SizeValueType>( m_Points.size() ); }
 
   /** Method returns the Point closest to the given point */
-  TSpatialObjectPointType ClosestPointInWorldSpace(const PointType & worldPoint) const;
+  TSpatialObjectPointType ClosestPointInWorldSpace(
+    const PointType & point) const;
+
+  TSpatialObjectPointType ClosestPointInObjectSpace(
+    const PointType & point) const;
 
   /** Returns true if the point is inside the Blob, false otherwise. */
-  bool IsInsideInWorldSpace(const PointType & worldPoint, unsigned int depth=0,
+  bool IsInsideInObjectSpace(const PointType & worldPoint, unsigned int depth=0,
     const std::string & name="") const override;
 
   /** Compute the boundaries of the Blob. */
-  bool ComputeMyBoundingBoxInWorldSpace() const override;
+  bool ComputeMyBoundingBox() const override;
 
 protected:
   PointBasedSpatialObject();

--- a/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPointBasedSpatialObject.hxx
@@ -74,6 +74,41 @@ PointBasedSpatialObject< TDimension, TSpatialObjectPointType >
 template< unsigned int TDimension, class TSpatialObjectPointType >
 TSpatialObjectPointType
 PointBasedSpatialObject< TDimension, TSpatialObjectPointType >
+::ClosestPointInObjectSpace( const PointType & point ) const
+{
+  auto it = m_Points.begin();
+  auto itend = m_Points.end();
+
+  if ( it == itend )
+    {
+    ExceptionObject exception(__FILE__, __LINE__);
+    exception.SetDescription(
+      "SpatialObject: ClosestPoint called using an empty point list");
+    throw exception;
+    }
+
+  SpatialObjectPointType closestPoint;
+  double closestPointDistance = NumericTraits< double >::max();
+  while ( it != itend )
+    {
+    typename SpatialObjectPoint< TDimension >::PointType curpos =
+      ( *it ).GetPositionInObjectSpace();
+    double curdistance = curpos.EuclideanDistanceTo(point);
+    if ( curdistance < closestPointDistance )
+      {
+      closestPoint = (*it);
+      closestPointDistance = curdistance;
+      }
+    it++;
+    }
+
+  return closestPoint;
+}
+
+/** Determine closest point in world space */
+template< unsigned int TDimension, class TSpatialObjectPointType >
+TSpatialObjectPointType
+PointBasedSpatialObject< TDimension, TSpatialObjectPointType >
 ::ClosestPointInWorldSpace( const PointType & point ) const
 {
   auto it = m_Points.begin();
@@ -105,11 +140,11 @@ PointBasedSpatialObject< TDimension, TSpatialObjectPointType >
   return closestPoint;
 }
 
-/** Compute bounding box of just this object in world space */
+/** Compute bounding box of just this object */
 template< unsigned int TDimension, class TSpatialObjectPointType >
 bool
 PointBasedSpatialObject< TDimension, TSpatialObjectPointType >
-::ComputeMyBoundingBoxInWorldSpace() const
+::ComputeMyBoundingBox() const
 {
   itkDebugMacro("Computing blob bounding box");
 
@@ -123,42 +158,16 @@ PointBasedSpatialObject< TDimension, TSpatialObjectPointType >
 
   PointType pt = ( *it ).GetPositionInObjectSpace();
 
-  // Compute a bounding box in object space
-  typename BoundingBoxType::Pointer bb = BoundingBoxType::New();
-
-  bb->SetMinimum(pt);
-  bb->SetMaximum(pt);
+  this->GetMyBoundingBoxInObjectSpace()->SetMinimum(pt);
+  this->GetMyBoundingBoxInObjectSpace()->SetMaximum(pt);
   it++;
   while ( it != end )
     {
-    bb->ConsiderPoint( ( *it ).GetPositionInObjectSpace() );
+    this->GetMyBoundingBoxInObjectSpace()->ConsiderPoint(
+      ( *it ).GetPositionInObjectSpace() );
     it++;
     }
-  bb->ComputeBoundingBox();
-
-  // Next Transform the corners of the bounding box into world space
-  using PointsContainer = typename BoundingBoxType::PointsContainer;
-  const PointsContainer *corners = bb->GetCorners();
-  typename PointsContainer::Pointer transformedCorners =
-    PointsContainer::New();
-  transformedCorners->Reserve(
-    static_cast<typename PointsContainer::ElementIdentifier>(
-      corners->size() ) );
-
-  auto itCorners = corners->begin();
-  auto itTrans = transformedCorners->begin();
-  while ( itCorners != corners->end() )
-    {
-    PointType pnt = this->GetObjectToWorldTransform()->TransformPoint(*itCorners);
-    *itTrans = pnt;
-    ++itCorners;
-    ++itTrans;
-    }
-
-  // refresh the object's bounding box with the transformed corners
-  const_cast< BoundingBoxType * >( this->GetMyBoundingBoxInWorldSpace() )
-    ->SetPoints(transformedCorners);
-  this->GetMyBoundingBoxInWorldSpace()->ComputeBoundingBox();
+  this->GetMyBoundingBoxInObjectSpace()->ComputeBoundingBox();
 
   return true;
 }
@@ -168,26 +177,22 @@ PointBasedSpatialObject< TDimension, TSpatialObjectPointType >
 template< unsigned int TDimension, class TSpatialObjectPointType >
 bool
 PointBasedSpatialObject< TDimension, TSpatialObjectPointType >
-::IsInsideInWorldSpace( const PointType & point, unsigned int depth,
+::IsInsideInObjectSpace( const PointType & point, unsigned int depth,
     const std::string & name) const
 {
   if( this->GetTypeName().find( name ) != std::string::npos )
     {
-    if( this->GetMyBoundingBoxInWorldSpace()->IsInside( point ) )
+    if( this->GetMyBoundingBoxInObjectSpace()->IsInside( point ) )
       {
       auto it = m_Points.begin();
       auto itEnd = m_Points.end();
-
-      PointType transformedPoint =
-        this->GetObjectToWorldTransform()->GetInverseTransform()->
-          TransformPoint(point);
 
       while ( it != itEnd )
         {
         bool equals = true;
         for( unsigned int i=0; i<TDimension; ++i )
           {
-          if( ! Math::AlmostEquals( transformedPoint[i],
+          if( ! Math::AlmostEquals( point[i],
               it->GetPositionInObjectSpace()[i] ) )
             {
             equals = false;
@@ -205,7 +210,7 @@ PointBasedSpatialObject< TDimension, TSpatialObjectPointType >
 
   if( depth > 0 )
     {
-    return Superclass::IsInsideChildrenInWorldSpace(point, depth-1, name);
+    return Superclass::IsInsideChildrenInObjectSpace(point, depth-1, name);
     }
 
   return false;

--- a/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.h
@@ -72,10 +72,8 @@ public:
   /** Method returns the length of the perimeter */
   double MeasurePerimeter() const;
 
-  // For ComputeMyBounds - use the implementation in PointBasedSpatialObject
-
   /** Test whether a point is inside or outside the object. */
-  bool IsInsideInWorldSpace(const PointType & point, unsigned int depth,
+  bool IsInsideInObjectSpace(const PointType & point, unsigned int depth,
     const std::string & name) const override;
 
 protected:

--- a/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkPolygonSpatialObject.hxx
@@ -57,8 +57,7 @@ PolygonSpatialObject< TDimension >
   maxPnt.Fill( NumericTraits< double >::NonpositiveMin() );
   while ( it != itend )
     {
-    PointType curpoint = this->GetObjectToWorldTransform()->TransformPoint(
-      ( *it ).GetPositionInObjectSpace() );
+    PointType curpoint = ( *it ).GetPositionInObjectSpace();
     for ( unsigned int i = 0; i < TDimension; i++ )
       {
       if ( minPnt[i] > curpoint[i] )
@@ -75,7 +74,7 @@ PolygonSpatialObject< TDimension >
   m_OrientationInObjectSpace = -1;
   for ( unsigned int i = 0; i < TDimension; i++ )
     {
-    if ( Math::ExactlyEquals(minPnt[0], maxPnt[0]) )
+    if ( Math::ExactlyEquals(minPnt[i], maxPnt[i]) )
       {
       m_OrientationInObjectSpace = i;
       break;
@@ -207,12 +206,13 @@ PolygonSpatialObject< TDimension >
 template< unsigned int TDimension >
 bool
 PolygonSpatialObject< TDimension >
-::IsInsideInWorldSpace(const PointType & worldPoint, unsigned int depth,
+::IsInsideInObjectSpace(const PointType & point, unsigned int depth,
   const std::string & name) const
 {
   if( this->GetTypeName().find( name ) != std::string::npos )
     {
-    if( this->IsClosed() && this->GetMyBoundingBoxInWorldSpace()->IsInside( worldPoint ) )
+    if( this->IsClosed()
+      && this->GetMyBoundingBoxInObjectSpace()->IsInside( point ) )
       {
       int    numpoints = this->GetNumberOfPoints();
       int    X = -1;
@@ -236,9 +236,6 @@ PolygonSpatialObject< TDimension >
             }
           }
 
-        PointType transformedPoint = this->GetObjectToWorldTransform()->
-          GetInverseTransform()->TransformPoint( worldPoint );
-
         const PolygonPointListType & points = this->GetPoints();
         auto it = points.begin();
         auto itend = points.end();
@@ -261,8 +258,8 @@ PolygonSpatialObject< TDimension >
             continue;
             }
 
-          const double x = transformedPoint[X];
-          const double y = transformedPoint[Y];
+          const double x = point[X];
+          const double y = point[Y];
 
           if ( ( node1[Y] < y && node2[Y] >= y )
                || ( node2[Y] < y && node1[Y] >= y ) )
@@ -285,7 +282,7 @@ PolygonSpatialObject< TDimension >
 
   if( depth > 0 )
     {
-    return Superclass::IsInsideChildrenInWorldSpace( worldPoint, depth-1, name );
+    return Superclass::IsInsideChildrenInObjectSpace( point, depth-1, name );
     }
 
   return false;

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageFilter.hxx
@@ -303,7 +303,7 @@ SpatialObjectToImageFilter< TInputSpatialObject, TOutputImage >
   // Generate the image
   SizeType size;
 
-  InputObject->ComputeFamilyBoundingBoxInWorldSpace( m_ChildrenDepth );
+  InputObject->ComputeFamilyBoundingBox( m_ChildrenDepth );
   for ( i = 0; i < ObjectDimension; i++ )
     {
     size[i] = static_cast<SizeValueType>(

--- a/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
+++ b/Modules/Core/SpatialObjects/include/itkSpatialObjectToImageStatisticsCalculator.hxx
@@ -152,7 +152,7 @@ SpatialObjectToImageStatisticsCalculator< TInputImage, TInputSpatialObject, TSam
     {
     // Get the bounding box
     typename SpatialObjectType::BoundingBoxType::Pointer boundingBox;
-    m_SpatialObject->ComputeMyBoundingBoxInWorldSpace();
+    m_SpatialObject->ComputeMyBoundingBox();
     boundingBox = m_SpatialObject->GetMyBoundingBoxInWorldSpace();
 
     Point< double, Self::ObjectDimension > pt;

--- a/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
+++ b/Modules/Core/SpatialObjects/include/itkTubeSpatialObject.h
@@ -100,10 +100,10 @@ public:
   itkGetConstMacro(Root, bool);
 
   /** Compute the boundaries of the tube. */
-  bool ComputeMyBoundingBoxInWorldSpace() const override;
+  bool ComputeMyBoundingBox() const override;
 
   /** Returns true if the point is inside the tube, false otherwise. */
-  bool IsInsideInWorldSpace(const PointType & point, unsigned int depth = 0,
+  bool IsInsideInObjectSpace(const PointType & point, unsigned int depth = 0,
     const std::string & name = "") const override;
 
 

--- a/Modules/Core/SpatialObjects/test/itkArrowSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkArrowSpatialObjectTest.cxx
@@ -29,9 +29,25 @@ int itkArrowSpatialObjectTest(int, char* [])
 
   ArrowType::Pointer myArrow = ArrowType::New();
 
+  // Testing the position
+  std::cout << "Testing position : ";
+  ArrowType::PointType pnt;
+  pnt[0] = 0;
+  pnt[1] = 1;
+  pnt[2] = 0;
+  myArrow->SetPositionInObjectSpace(pnt);
+  myArrow->Update();
+  if(itk::Math::NotExactlyEquals(myArrow->GetPositionInObjectSpace()[1], 1))
+    {
+    std::cout << "[FAILURE]" << std::endl;
+    return EXIT_FAILURE;
+    }
+  std::cout << "[PASSED]" << std::endl;
+
   // Testing the length
   std::cout << "Testing length : ";
   myArrow->SetLengthInObjectSpace(2);
+  myArrow->Update();
   if(itk::Math::NotExactlyEquals(myArrow->GetLengthInObjectSpace(), 2))
     {
     std::cout << "[FAILURE]" << std::endl;
@@ -48,6 +64,7 @@ int itkArrowSpatialObjectTest(int, char* [])
   direction[1] = 1.0;
 
   myArrow->SetDirectionInObjectSpace(direction);
+  myArrow->Update();
   if(itk::Math::NotExactlyEquals(myArrow->GetDirectionInObjectSpace()[0], 0)
     || itk::Math::NotExactlyEquals(myArrow->GetDirectionInObjectSpace()[1], 1)
     || itk::Math::NotExactlyEquals(myArrow->GetDirectionInObjectSpace()[2], 0)
@@ -59,32 +76,37 @@ int itkArrowSpatialObjectTest(int, char* [])
   std::cout << "[PASSED]" << std::endl;
 
   // Point consistency
-  std::cout << "Is Inside: ";
+  std::cout << "Is Inside (Inside): ";
   itk::Point<double,3> in;
-  in[0]=0;in[1]=1;in[2]=0;
-  itk::Point<double,3> out;
-  out[0]=0;out[1]=2.1;out[2]=0;
-
+  in[0]=0;
+  in[1]=1;
+  in[2]=0;
   if(!myArrow->IsInsideInWorldSpace(in))
   {
     std::cout<<"[FAILED]"<<std::endl;
     return EXIT_FAILURE;
   }
+  std::cout<<"[PASSED]"<<std::endl;
 
+  std::cout << "Is Inside (Outside): ";
+  itk::Point<double,3> out;
+  out[0]=0;
+  out[1]=2.1;
+  out[2]=0;
   if(myArrow->IsInsideInWorldSpace(out))
   {
     std::cout<<"[FAILED]"<<std::endl;
     return EXIT_FAILURE;
   }
-
   std::cout<<"[PASSED]"<<std::endl;
 
 
-  std::cout << "ComputeMyBoundingBoxInWorldSpace: ";
-  myArrow->Update();
-  ArrowType::BoundingBoxType * boundingBox = myArrow->GetMyBoundingBoxInWorldSpace();
+  std::cout << "ComputeMyBoundingBox: ";
+  ArrowType::BoundingBoxType * boundingBox =
+    myArrow->GetMyBoundingBoxInWorldSpace();
 
-  if( (itk::Math::NotExactlyEquals(boundingBox->GetBounds()[2], 0) )
+  std::cout << boundingBox->GetBounds() << std::endl;
+  if( (itk::Math::NotExactlyEquals(boundingBox->GetBounds()[2], 1) )
      || (itk::Math::NotExactlyEquals(boundingBox->GetBounds()[3], 1) )
       )
     {

--- a/Modules/Core/SpatialObjects/test/itkBoxSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkBoxSpatialObjectTest.cxx
@@ -67,8 +67,7 @@ int itkBoxSpatialObjectTest( int argc, char *argv[] )
 
   offset1[0] =  29.0;
   offset1[1] =  29.0;
-  box1->GetObjectToParentTransform()->SetOffset( offset1 );
-  box1->ComputeObjectToWorldTransform();
+  box1->GetModifiableObjectToParentTransform()->SetOffset( offset1 );
   box1->Update();
 
   offset2[0] = 50.0;
@@ -76,7 +75,9 @@ int itkBoxSpatialObjectTest( int argc, char *argv[] )
   box2->SetPositionInObjectSpace( offset2 );
   box2->Update();
 
-  std::cout <<"Test ComputeMyBoundingBoxInWorldSpace: " << std::endl;
+  scene->ComputeObjectToWorldTransform();
+
+  std::cout <<"Test ComputeMyBoundingBox: " << std::endl;
   std::cout << box1->GetMyBoundingBoxInWorldSpace()->GetBounds() << std::endl;
   std::cout << box2->GetMyBoundingBoxInWorldSpace()->GetBounds() << std::endl;
   BoxType::BoundingBoxType * boundingBox = box1->GetMyBoundingBoxInWorldSpace();
@@ -92,8 +93,9 @@ int itkBoxSpatialObjectTest( int argc, char *argv[] )
     return EXIT_FAILURE;
     }
 
-  box2->ComputeFamilyBoundingBoxInWorldSpace();
-  BoxType::BoundingBoxType * boundingBox2 = box2->GetFamilyBoundingBoxInWorldSpace();
+  box2->ComputeFamilyBoundingBox();
+  BoxType::BoundingBoxType * boundingBox2
+    = box2->GetFamilyBoundingBoxInWorldSpace();
   if(     itk::Math::NotAlmostEquals(boundingBox2->GetBounds()[0], 50)
       ||  itk::Math::NotAlmostEquals(boundingBox2->GetBounds()[1], 80)
       ||  itk::Math::NotAlmostEquals(boundingBox2->GetBounds()[2], 50)
@@ -110,36 +112,27 @@ int itkBoxSpatialObjectTest( int argc, char *argv[] )
   // Point consistency
   std::cout << "Test Is Inside: ";
   itk::Point<double,2> in;
-  in[0]=30.0;in[1]=30.0;
+  in[0]=30.0;
+  in[1]=30.0;
   itk::Point<double,2> out;
-  out[0]=0;out[1]=4;
+  out[0]=0;
+  out[1]=4;
 
   if(!box1->IsInsideInWorldSpace(in))
-  {
+    {
     std::cout<<"[FAILED]"<<std::endl;
     return EXIT_FAILURE;
-  }
+    }
   if(box1->IsInsideInWorldSpace(out))
-  {
+    {
     std::cout<<"[FAILED]"<<std::endl;
     return EXIT_FAILURE;
-  }
+    }
   std::cout << "[PASSED]" << std::endl;
 
-  std::cout << "Test ObjectToWorldTransform " << std::endl;
-
-  BoxType::TransformType::OffsetType translation;
-  translation[0] =  5.0;
-  translation[1] =  5.0;
-  box1->GetObjectToParentTransform()->Translate( translation );
-  box1->GetObjectToParentTransform()->SetOffset( offset1 );
-  box1->ComputeObjectToWorldTransform();
-  box2->GetObjectToParentTransform()->Translate( translation );
-  box2->GetObjectToParentTransform()->SetOffset( offset2 );
-  box2->ComputeObjectToWorldTransform();
-
-  SpatialObjectToImageFilterType::Pointer imageFilter =
-                            SpatialObjectToImageFilterType::New();
+  std::cout << "Test SpatialObjectToImageFilter / IsInside " << std::endl;
+  SpatialObjectToImageFilterType::Pointer imageFilter
+    = SpatialObjectToImageFilterType::New();
   imageFilter->SetInput(  scene  );
 
   OutputImageType::SizeType size;
@@ -168,7 +161,7 @@ int itkBoxSpatialObjectTest( int argc, char *argv[] )
     {
     std::cout << "ExceptionObject caught !" << std::endl;
     std::cout << err << std::endl;
-    return -1;
+    return EXIT_FAILURE;
     }
   box1->Print(std::cout);
   return EXIT_SUCCESS;

--- a/Modules/Core/SpatialObjects/test/itkContourSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkContourSpatialObjectTest.cxx
@@ -63,7 +63,7 @@ int itkContourSpatialObjectTest(int, char* [])
 
 
   //
-  // Test ComputeMyBoundingBoxInWorldSpace before data added
+  // Test ComputeMyBoundingBox before data added
   //
   contour->Update();
 
@@ -224,6 +224,9 @@ int itkContourSpatialObjectTest(int, char* [])
   interpPointList.push_back(intPt2);
 
   contour->SetControlPoints(interpPointList);
+  contour->SetInterpolationMethod(
+    SpatialObjectType::InterpolationMethodType::NO_INTERPOLATION);
+  contour->Update();
 
   // check number of points
   if (contour->GetNumberOfControlPoints() != 2)
@@ -273,7 +276,7 @@ int itkContourSpatialObjectTest(int, char* [])
   //
   // Test ComputeLocalBoundingBox
   //
-  if (!contour->ComputeMyBoundingBoxInWorldSpace())
+  if (!contour->ComputeMyBoundingBox())
     {
     std::cout << "[FAILED] faild bounding box computation" << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Core/SpatialObjects/test/itkEllipseSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkEllipseSpatialObjectTest.cxx
@@ -41,6 +41,7 @@ int itkEllipseSpatialObjectTest(int, char* [])
   std::cout << "Testing radii : ";
 
   myEllipse->SetRadiusInObjectSpace(radius);
+  myEllipse->Update();
   EllipseType::ArrayType radius2 = myEllipse->GetRadiusInObjectSpace();
   for(unsigned int i = 0; i<4;i++)
   {
@@ -53,7 +54,8 @@ int itkEllipseSpatialObjectTest(int, char* [])
   std::cout << "[PASSED]" << std::endl;
 
   myEllipse->SetRadiusInObjectSpace(3);
- EllipseType::ArrayType radius3 = myEllipse->GetRadiusInObjectSpace();
+  myEllipse->Update();
+  EllipseType::ArrayType radius3 = myEllipse->GetRadiusInObjectSpace();
   std::cout << "Testing Global radii : ";
   for(unsigned int i = 0; i<4;i++)
   {
@@ -69,9 +71,15 @@ int itkEllipseSpatialObjectTest(int, char* [])
    // Point consistency
   std::cout << "Is Inside: ";
   itk::Point<double,4> in;
-  in[0]=1;in[1]=2;in[2]=1;in[3]=1;
+  in[0]=1;
+  in[1]=2;
+  in[2]=1;
+  in[3]=1;
   itk::Point<double,4> out;
-  out[0]=0;out[1]=4;out[2]=0;out[3]=0;
+  out[0]=0;
+  out[1]=4;
+  out[2]=0;
+  out[3]=0;
 
   if(!myEllipse->IsInsideInWorldSpace(in))
   {
@@ -94,10 +102,10 @@ int itkEllipseSpatialObjectTest(int, char* [])
   EllipseType::Pointer myEllipse2 = EllipseType::New();
   myEllipse2->SetRadiusInObjectSpace(1);
   myEllipse->AddChild(myEllipse2);
+  myEllipse->ComputeObjectToWorldTransform();
 
   EllipseType::TransformType::OffsetType offset;
   offset.Fill(10);
-
   myEllipse->GetModifiableObjectToWorldTransform()->SetOffset(offset);
   myEllipse->ComputeObjectToParentTransform();
 
@@ -107,10 +115,12 @@ int itkEllipseSpatialObjectTest(int, char* [])
   myEllipse2->ComputeObjectToParentTransform();
 
   EllipseType::TransformType::OffsetType offset3;
-  offset3 = myEllipse2->GetObjectToParentTransform()->GetOffset();
+  offset3 = myEllipse2->GetModifiableObjectToParentTransform()->GetOffset();
 
-  if( (itk::Math::NotExactlyEquals(offset3[0],5)) || (itk::Math::NotExactlyEquals(offset3[1],5))
-     ||(itk::Math::NotExactlyEquals(offset3[2],5)) ||(itk::Math::NotExactlyEquals(offset3[3],5))
+  if( (itk::Math::NotExactlyEquals(offset3[0],5))
+     || (itk::Math::NotExactlyEquals(offset3[1],5))
+     ||(itk::Math::NotExactlyEquals(offset3[2],5))
+     ||(itk::Math::NotExactlyEquals(offset3[3],5))
      )
   {
     std::cout<<"[FAILED]"<<std::endl;
@@ -118,10 +128,12 @@ int itkEllipseSpatialObjectTest(int, char* [])
   }
   std::cout<<"[PASSED]"<<std::endl;
 
-  std::cout << "ComputeMyBoundingBoxInWorldSpace: ";
-  myEllipse->ComputeMyBoundingBoxInWorldSpace();
-  EllipseType::BoundingBoxType * boundingBox = myEllipse->GetMyBoundingBoxInWorldSpace();
+  myEllipse->ComputeMyBoundingBox();
+  EllipseType::BoundingBoxType * boundingBox
+    = myEllipse->GetFamilyBoundingBoxInWorldSpace();
+  std::cout << "Bounds = " << boundingBox->GetBounds() << std::endl;
 
+  std::cout << "ComputeMyBoundingBox: ";
   for(unsigned int i=0;i<3;i++)
   {
     if(   itk::Math::NotAlmostEquals(boundingBox->GetBounds()[2*i], 7 )

--- a/Modules/Core/SpatialObjects/test/itkGaussianSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkGaussianSpatialObjectTest.cxx
@@ -111,7 +111,7 @@ int itkGaussianSpatialObjectTest(int, char* [])
 
   GaussianType::TransformType::OffsetType offset3;
 
-  offset3 = myGaussian2->GetObjectToParentTransform()->GetOffset();
+  offset3 = myGaussian2->GetModifiableObjectToParentTransform()->GetOffset();
 
   if(    itk::Math::NotAlmostEquals(offset3[0], 5.0) || itk::Math::NotAlmostEquals(offset3[1], 5.0)
       || itk::Math::NotAlmostEquals(offset3[2], 5.0) || itk::Math::NotAlmostEquals(offset3[3], 5.0)
@@ -123,8 +123,8 @@ int itkGaussianSpatialObjectTest(int, char* [])
   std::cout<<"[PASSED]"<<std::endl;
 
 
-  std::cout << "ComputeMyBoundingBoxInWorldSpace: ";
-  myGaussian->ComputeMyBoundingBoxInWorldSpace();
+  std::cout << "ComputeMyBoundingBox: ";
+  myGaussian->ComputeMyBoundingBox();
   GaussianType::BoundingBoxType * boundingBox = myGaussian->GetMyBoundingBoxInWorldSpace();
 
   for(unsigned int i=0;i<3;i++)

--- a/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageSpatialObjectTest.cxx
@@ -75,7 +75,7 @@ int itkImageSpatialObjectTest(int, char* [])
   ImageSpatialObject::TransformType::OffsetType offset;
   offset.Fill(5);
 
-  imageSO->GetObjectToParentTransform()->SetOffset(offset);
+  imageSO->GetModifiableObjectToParentTransform()->SetOffset(offset);
   imageSO->ComputeObjectToWorldTransform();
 
   PointType q;
@@ -86,7 +86,7 @@ int itkImageSpatialObjectTest(int, char* [])
   r.Fill(9);
   q.Fill(15);
 
-  imageSO->ComputeMyBoundingBoxInWorldSpace();
+  imageSO->ComputeMyBoundingBox();
   std::cout << "Bounding Box = "
     << imageSO->GetMyBoundingBoxInWorldSpace()->GetBounds() << std::endl;
   std::cout<<"IsInside()...";

--- a/Modules/Core/SpatialObjects/test/itkLineSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkLineSpatialObjectTest.cxx
@@ -62,7 +62,7 @@ int itkLineSpatialObjectTest(int, char* [])
   Line->GetProperty().SetName("Line 1");
   Line->SetId(1);
   Line->SetPoints(list);
-  Line->ComputeMyBoundingBoxInWorldSpace();
+  Line->ComputeMyBoundingBox();
 
  // Number of points
   std::cout << "Testing Consistency: " << std::endl;

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageFilterTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageFilterTest.cxx
@@ -41,7 +41,7 @@ int itkSpatialObjectToImageFilterTest(int, char* [] )
   // Center the circle in the image
   EllipseType::TransformType::OffsetType offset;
   offset.Fill(25);
-  ellipse->GetObjectToParentTransform()->SetOffset(offset);
+  ellipse->GetModifiableObjectToParentTransform()->SetOffset(offset);
   ellipse->ComputeObjectToWorldTransform();
 
   using ImageType = itk::Image<double,2>;

--- a/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageStatisticsCalculatorTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkSpatialObjectToImageStatisticsCalculatorTest.cxx
@@ -40,7 +40,7 @@ int itkSpatialObjectToImageStatisticsCalculatorTest(int, char * [] )
 
   EllipseType::VectorType offset;
   offset.Fill(25);
-  ellipse->GetObjectToParentTransform()->SetOffset(offset);
+  ellipse->GetModifiableObjectToParentTransform()->SetOffset(offset);
   ellipse->ComputeObjectToParentTransform();
 
 
@@ -55,7 +55,7 @@ int itkSpatialObjectToImageStatisticsCalculatorTest(int, char * [] )
   ImageType::Pointer image = filter->GetOutput();
 
   offset.Fill(25);
-  ellipse->GetObjectToParentTransform()->SetOffset(offset);
+  ellipse->GetModifiableObjectToParentTransform()->SetOffset(offset);
   ellipse->ComputeObjectToParentTransform();
 
 
@@ -82,7 +82,7 @@ int itkSpatialObjectToImageStatisticsCalculatorTest(int, char * [] )
   std::cout << "[PASSED]" << std::endl;
 
   offset.Fill(20);
-  ellipse->GetObjectToParentTransform()->SetOffset(offset);
+  ellipse->GetModifiableObjectToParentTransform()->SetOffset(offset);
   ellipse->ComputeObjectToParentTransform();
   ellipse->Update();
   calculator->Update();
@@ -104,7 +104,7 @@ int itkSpatialObjectToImageStatisticsCalculatorTest(int, char * [] )
   std::cout << " --- Ellipse and Image mismatched right --- " << std::endl;
 
   offset.Fill(30);
-  ellipse->GetObjectToParentTransform()->SetOffset(offset);
+  ellipse->GetModifiableObjectToParentTransform()->SetOffset(offset);
   ellipse->ComputeObjectToParentTransform();
   ellipse->Update();
   calculator->Update();
@@ -183,7 +183,7 @@ int itkSpatialObjectToImageStatisticsCalculatorTest(int, char * [] )
   Ellipse3DType::VectorType offset3D;
   offset3D.Fill(25);
   offset3D[2]=0; // first slice
-  ellipse3D->GetObjectToParentTransform()->SetOffset(offset3D);
+  ellipse3D->GetModifiableObjectToParentTransform()->SetOffset(offset3D);
   ellipse3D->ComputeObjectToParentTransform();
 
   // Create a new calculator with a sample size of 3

--- a/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkTubeSpatialObjectTest.cxx
@@ -59,7 +59,7 @@ int itkTubeSpatialObjectTest(int, char * [] )
 
   TubeType::TransformType::OffsetType offset;
   offset.Fill(10);
-  tube1->GetObjectToParentTransform()->SetOffset(offset);
+  tube1->GetModifiableObjectToParentTransform()->SetOffset(offset);
   tube1->ComputeObjectToWorldTransform();
 
   for( unsigned int i=0; i<10; i++)
@@ -77,7 +77,7 @@ int itkTubeSpatialObjectTest(int, char * [] )
   p.Print(std::cout);
 
   tube1->SetPoints(list);
-  tube1->ComputeMyBoundingBoxInWorldSpace();
+  tube1->ComputeMyBoundingBox();
 
   in.Fill(15);
   out.Fill(5);
@@ -144,13 +144,13 @@ int itkTubeSpatialObjectTest(int, char * [] )
   tube2->GetProperty().SetName("Tube 2");
   tube2->SetId(2);
   tube2->SetPoints(list);
-  tube2->ComputeMyBoundingBoxInWorldSpace();
+  tube2->ComputeMyBoundingBox();
 
   TubePointer tube3 = TubeType::New();
   tube3->GetProperty().SetName("Tube 3");
   tube3->SetId(3);
   tube3->SetPoints(list);
-  tube3->ComputeMyBoundingBoxInWorldSpace();
+  tube3->ComputeMyBoundingBox();
 
   GroupPointer tubeNet1 = GroupType::New();
   tubeNet1->GetProperty().SetName("tube network 1");
@@ -280,7 +280,7 @@ int itkTubeSpatialObjectTest(int, char * [] )
     std::cout<<"[PASSED]"<<std::endl;
     }
 
-  tubeNet1->ComputeMyBoundingBoxInWorldSpace();
+  tubeNet1->ComputeMyBoundingBox();
 
   std::cout<<"HasParent()...";
   if( !tube2->HasParent() )
@@ -294,17 +294,17 @@ int itkTubeSpatialObjectTest(int, char * [] )
     }
 
   translation.Fill(10);
-  tubeNet1->GetObjectToParentTransform()->Translate(translation,false);
+  tubeNet1->GetModifiableObjectToParentTransform()->Translate(translation,false);
   tubeNet1->ComputeObjectToWorldTransform();
 
   axis.Fill(0);
   axis[1] = 1;
   angle = itk::Math::pi_over_2;
-  tube2->GetObjectToParentTransform()->Rotate3D(axis,angle);
+  tube2->GetModifiableObjectToParentTransform()->Rotate3D(axis,angle);
   tube2->ComputeObjectToWorldTransform();
 
   angle = -itk::Math::pi_over_2;
-  tube3->GetObjectToParentTransform()->Rotate3D(axis,angle);
+  tube3->GetModifiableObjectToParentTransform()->Rotate3D(axis,angle);
   tube3->ComputeObjectToWorldTransform();
 
   in.Fill(25);
@@ -474,7 +474,7 @@ int itkTubeSpatialObjectTest(int, char * [] )
   using PointBasedType = itk::PointBasedSpatialObject<3>;
   PointBasedType::Pointer pBSO = PointBasedType::New();
   pBSO->GetPoint(0);
-  pBSO->ComputeMyBoundingBoxInWorldSpace();
+  pBSO->ComputeMyBoundingBox();
   std::cout << "[PASSED]" << std::endl;
 
   std::cout << "[DONE]" << std::endl;

--- a/Modules/Core/SpatialObjects/wrapping/CMakeLists.txt
+++ b/Modules/Core/SpatialObjects/wrapping/CMakeLists.txt
@@ -11,10 +11,10 @@ set(WRAPPER_SUBMODULE_ORDER
   itkTubeSpatialObject
   itkDTITubeSpatialObjectPoint
   itkDTITubeSpatialObject
-  itkLineSpatialObject
   itkLineSpatialObjectPoint
-  itkSurfaceSpatialObject
+  itkLineSpatialObject
   itkSurfaceSpatialObjectPoint
+  itkSurfaceSpatialObject
   itkLandmarkSpatialObject
   itkBlobSpatialObject
   itkPolygonSpatialObject

--- a/Modules/Core/SpatialObjects/wrapping/itkTubeSpatialObject.wrap
+++ b/Modules/Core/SpatialObjects/wrapping/itkTubeSpatialObject.wrap
@@ -1,0 +1,11 @@
+itk_wrap_class("itk::PointBasedSpatialObject" POINTER)
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    itk_wrap_template("Tube${d}" "${d}, itk::TubeSpatialObjectPoint<${d}>")
+  endforeach()
+itk_end_wrap_class()
+
+itk_wrap_class("itk::TubeSpatialObject" POINTER)
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    itk_wrap_template(${d} ${d})
+  endforeach()
+itk_end_wrap_class()


### PR DESCRIPTION
ENH: ComputeMy/FamilyBoundingBox decoupled from world space.
This allows BoundingBoxes to be computed independent of
transform validity.

Now object shape definitions (e.g., bounding boxes) are independent
of the object's transforms.

1) Update should be called if a shape is modified.

2) ComputeObjectToWorldTransform should be called when a transform
is modified.