### PR TITLE
BUG: Missing center computation in isInside function for Ellipse

### DIFF
--- a/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
+++ b/Modules/Core/SpatialObjects/include/itkEllipseSpatialObject.hxx
@@ -50,15 +50,18 @@ EllipseSpatialObject< TDimension >
 {
   if( this->GetTypeName().find( name ) != std::string::npos )
     {
+    double d;
     double r = 0;
     for ( unsigned int i = 0; i < TDimension; i++ )
       {
-      if ( m_RadiusInObjectSpace[i] != 0.0 )
+      if ( m_RadiusInObjectSpace[i] > 0.0 )
         {
-        r += ( point[i] * point[i] )
-             / ( m_RadiusInObjectSpace[i] * m_RadiusInObjectSpace[i] );
+        d = point[i] - m_CenterInObjectSpace[i];
+        r += ( d * d )
+          / ( m_RadiusInObjectSpace[i] * m_RadiusInObjectSpace[i] );
         }
-      else if ( point[i] > 0.0 )  // Degenerate ellipse
+      else if ( point[i] != 0.0 || m_RadiusInObjectSpace[i] < 0 )
+        // Deal with an ellipse with 0 or negative radius;
         {
         r = 2; // Keeps function from returning true here
         break;

--- a/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
@@ -180,8 +180,10 @@ namespace
 
     if ( circles1.size() != circles2.size() )
     {
-      // The choice of the radius image type should not affect the number of circles found.
-      std::cout << "The size of circles1 and circles2 should be equal, even while the radius image types differ!"
+      // The choice of the radius image type should not affect the number of
+      // circles found.
+      std::cout << "The size of circles1 and circles2 should be equal, even"
+        << " while the radius image types differ!"
         << std::endl;
       return false;
     }
@@ -206,8 +208,10 @@ namespace
 
     if (centerPoint1 != centerPoint2)
     {
-      // The choice of the radius image type should not affect the center estimation.
-      std::cout << "center1 and center2 should be equal, even while the radius image types differ!"
+      // The choice of the radius image type should not affect the center
+      // estimation.
+      std::cout << "center1 and center2 should be equal, even while the "
+        << "radius image types differ!"
         << std::endl;
       success = false;
     }
@@ -217,9 +221,11 @@ namespace
 
     if ( radius2 < radius1 )
     {
-      // The radius estimation of filter1 was truncated, whereas the radius estimation of filter2 was not,
+      // The radius estimation of filter1 was truncated, whereas the radius
+      // estimation of filter2 was not,
       // so radius2 is expected to be greater than or equal to radius1.
-      std::cout << "radius2 (radius image type double) should be >= radius1 (radius image type unsigned long)!"
+      std::cout << "radius2 (radius image type double) should be >= radius1"
+        << " (radius image type unsigned long)!"
         << std::endl;
       success = false;
     }
@@ -228,13 +234,15 @@ namespace
 
     if (!itk::Math::FloatAlmostEqual(radius1, radius, 0, radiusTolerance))
     {
-      std::cout << "Expected radius: " << radius << ", found radius1 = " << radius1 << std::endl;
+      std::cout << "Expected radius: " << radius << ", found radius1 = "
+        << radius1 << std::endl;
       success = false;
     }
 
     if (!itk::Math::FloatAlmostEqual(radius2, radius, 0, radiusTolerance))
     {
-      std::cout << "Expected radius: " << radius << ", found radius2 = " << radius2 << std::endl;
+      std::cout << "Expected radius: " << radius << ", found radius2 = "
+        << radius2 << std::endl;
       success = false;
     }
 
@@ -256,7 +264,8 @@ namespace
     const double radius = 1.0;
     CreateCircle<ImageType>(image, center, radius);
 
-    using FilterType = itk::HoughTransform2DCirclesImageFilter< PixelType, unsigned, double >;
+    using FilterType
+      = itk::HoughTransform2DCirclesImageFilter< PixelType, unsigned, double >;
     const auto filter = FilterType::New();
     filter->SetInput(image);
     filter->Update();
@@ -265,7 +274,9 @@ namespace
 
     if (circles.size() != 1)
     {
-      std::cout << "ERROR: GetCircles() should have found exactly one circle!" << std::endl;
+      std::cout
+        << "ERROR: GetCircles() should have found exactly one circle!"
+        << std::endl;
       return false;
     }
 
@@ -273,7 +284,9 @@ namespace
 
     if (circle == nullptr)
     {
-      std::cout << "ERROR: The circle found by GetCircles() should not be null!" << std::endl;
+      std::cout
+        << "ERROR: The circle found by GetCircles() should not be null!"
+        << std::endl;
       return false;
     }
 
@@ -282,8 +295,10 @@ namespace
     if (!isInside)
     {
       std::cout <<
-        "ERROR: The center of the actual circle should be inside the spacial object of the detected circle!"
+        "ERROR: The center of the actual circle should be inside the"
+        << " spacial object of the detected circle!"
         << std::endl;
+      std::cout << circle << std::endl;
     }
     return isInside;
   }


### PR DESCRIPTION
*This is a reminder of what a message in a pull request should minimally require. Please, **read the guidelines below**, and **delete** them so your pull request description only contains the intended message.*

See the [CONTRIBUTING](CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as the PR message.

A [reference to a related issue or pull request](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests) in your repository. You can automatically [close a related issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/)

[@mentions](https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams) of the person or team responsible for reviewing proposed changes.

**Thanks for contributing to ITK!**
